### PR TITLE
More missing

### DIFF
--- a/spec/expand/constants.spec
+++ b/spec/expand/constants.spec
@@ -24,3 +24,13 @@ a:b
 
 a:b:c
 a:b:c
+
+# Don't consume function name from constant!
+que
+que
+
+q
+q
+
+clusters
+clusters

--- a/spec/expand/default_cluster/at_operator.spec
+++ b/spec/expand/default_cluster/at_operator.spec
@@ -4,3 +4,6 @@ host2
 
 @{secure}
 host1
+
+@se{cu}re
+host1

--- a/spec/expand/default_cluster/at_operator.spec
+++ b/spec/expand/default_cluster/at_operator.spec
@@ -1,0 +1,6 @@
+@dc1
+host1
+host2
+
+@{secure}
+host1

--- a/spec/expand/parsing.spec
+++ b/spec/expand/parsing.spec
@@ -1,8 +1,14 @@
 # This file contains random parser regressions
 %{has(A;a) & has(B;b)}
 
+{}
+
 %{}
 
 %{}:EMPTY
 
 %a.b
+
+()
+
+%()


### PR DESCRIPTION
Pretty straightforward I think

This explicitly specs that `{}` evaluates to the null set (rather than one element `""`)

@drcapulet @eam 